### PR TITLE
Create CR - remove :project & :email

### DIFF
--- a/lib/hammer_cli_foreman_google/compute_resources/google.rb
+++ b/lib/hammer_cli_foreman_google/compute_resources/google.rb
@@ -25,8 +25,6 @@ module HammerCLIForemanGoogle
 
       def provider_specific_fields
         [
-          Fields::Field.new(label: _('Project'), path: [:project]),
-          Fields::Field.new(label: _('Email'), path: [:email]),
           Fields::Field.new(label: _('Key Path'), path: [:key_path]),
           Fields::Field.new(label: _('Zone'), path: [:zone])
         ]
@@ -42,7 +40,7 @@ module HammerCLIForemanGoogle
       end
 
       def mandatory_resource_options
-        super + %i[project key_path zone]
+        super + %i[key_path zone]
       end
     end
   end


### PR DESCRIPTION
:project & :email are loaded from the json file

**Tested commands**
Create CR:
```
hammer compute-resource create --name gce_ham \
--provider GCE --key-path ~/path/to/file.json --zone europe-west1-b
```
Create VM:
```
hammer host create \
--name "myhost$EPOCHSECONDS" \
--organization "Default Organization" \
--location "Default Location" \
--compute-resource "gce_ham" \
--provision-method 'image' \
--root-password "changeme" \
--interface "type=interface,domain_id=1,managed=true,primary=true,provision=true" \
--architecture x86_64 \
--operatingsystem "CentOS_Stream 8" \
--compute-attributes "machine_type=e2-micro,associate_external_ip=true" \
--volume="size_gb=23" \
--image "stream8"

```