### PR TITLE
Use theforeman-rubocop gem

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -14,3 +14,5 @@ jobs:
   rubocop:
     name: Rubocop
     uses: theforeman/actions/.github/workflows/rubocop.yml@v0
+    with:
+      command: bundle exec rubocop --parallel --format github

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,26 +1,9 @@
-require:
-  - rubocop-performance
+inherit_gem:
+  theforeman-rubocop:
+    - strictest.yml
 
 AllCops:
-  NewCops: enable
-
-Layout/LineLength:
-  Enabled: false
+  TargetRubyVersion: 2.7
 
 Metrics:
-  Enabled: false
-
-Style/Documentation:
-  Enabled: false
-
-Style/StringLiterals:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Gemspec/RequireMFA:
-  Enabled: false
-
-Style/SymbolProc:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,13 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
 
 gemspec
 
 gem 'gettext', '>= 3.1.3', '< 4.0.0'
 gem 'rake', '~> 13.0'
 
-group :test do
-  gem 'rubocop', '~> 1.57.0'
-  gem 'rubocop-performance', '~> 1.5.2'
-end
+gem 'theforeman-rubocop', '~> 0.1.0'
 
 # load local gemfile
 ['Gemfile.local.rb', 'Gemfile.local'].map do |file_name|

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require 'rake/testtask'
 require 'bundler/gem_tasks'
 
-require "hammer_cli_foreman_google/version"
-require "hammer_cli_foreman_google/i18n"
-require "hammer_cli/i18n/find_task"
+require 'hammer_cli_foreman_google/version'
+require 'hammer_cli_foreman_google/i18n'
+require 'hammer_cli/i18n/find_task'
 
 HammerCLI::I18n::FindTask.define(HammerCLIForemanGoogle::I18n::LocaleDomain.new, HammerCLIForemanGoogle.version)
 

--- a/hammer_cli_foreman_google.gemspec
+++ b/hammer_cli_foreman_google.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'hammer_cli_foreman_google/version'

--- a/lib/hammer_cli_foreman_google.rb
+++ b/lib/hammer_cli_foreman_google.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HammerCLIForemanGoogle
   require 'hammer_cli_foreman/compute_resource/register_compute_resources'
 

--- a/lib/hammer_cli_foreman_google/compute_resources/google.rb
+++ b/lib/hammer_cli_foreman_google/compute_resources/google.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'hammer_cli_foreman/compute_resource/base'
 
 module HammerCLIForemanGoogle
@@ -17,14 +19,14 @@ module HammerCLIForemanGoogle
 
       def volume_attributes
         [
-          ['size_gb', _('Volume size in GB, integer value')]
+          ['size_gb', _('Volume size in GB, integer value')],
         ]
       end
 
       def provider_specific_fields
         [
           Fields::Field.new(label: _('Key Path'), path: [:key_path]),
-          Fields::Field.new(label: _('Zone'), path: [:zone])
+          Fields::Field.new(label: _('Zone'), path: [:zone]),
         ]
       end
 
@@ -33,7 +35,7 @@ module HammerCLIForemanGoogle
           Fields::Field.new(label: _('Machine Type'), path: [:machine_type]),
           Fields::Field.new(label: _('Status'), path: [:status]),
           Fields::Field.new(label: _('Description'), path: [:description]),
-          Fields::Field.new(label: _('Zone'), path: [:zone])
+          Fields::Field.new(label: _('Zone'), path: [:zone]),
         ]
       end
 

--- a/lib/hammer_cli_foreman_google/i18n.rb
+++ b/lib/hammer_cli_foreman_google/i18n.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'hammer_cli/i18n'
 
 module HammerCLIForemanGoogle
@@ -24,5 +26,6 @@ module HammerCLIForemanGoogle
   end
 end
 
-domain = [HammerCLIForemanGoogle::I18n::LocaleDomain.new, HammerCLIForemanGoogle::I18n::SystemLocaleDomain.new].find { |d| d.available? }
+domain = [HammerCLIForemanGoogle::I18n::LocaleDomain.new,
+          HammerCLIForemanGoogle::I18n::SystemLocaleDomain.new].find(&:available?)
 HammerCLI::I18n.add_domain(domain) if domain

--- a/lib/hammer_cli_foreman_google/version.rb
+++ b/lib/hammer_cli_foreman_google/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HammerCLIForemanGoogle
   def self.version
     @version ||= Gem::Version.new '1.1.1'


### PR DESCRIPTION
Inherited strictest.yml here, this rules have NewCops enable config. Also dropped some cops from here because that was either included in the inherit file or was not needed anymore.

Also I fixed some cops Style/SymbolProc, Style/FrozenStringLiteralComment, Style/StringLiterals, and Layout/LineLength.

This is part of Rubocop standerdization, link for the reference:
https://community.theforeman.org/t/standardizing-rubocop-with-theforeman-rubocop/37239
https://github.com/theforeman/theforeman-rubocop/?tab=readme-ov-file#all-opinionated-cops-with-new-ones---strictest